### PR TITLE
Modified gmapping config parameters for improved mapping

### DIFF
--- a/stage_navigation/move_base_config/slam_gmapping.xml
+++ b/stage_navigation/move_base_config/slam_gmapping.xml
@@ -4,7 +4,8 @@
 			<param name="base_frame" value="base_footprint"/>
       <param name="odom_frame" value="odom"/>
       <param name="map_update_interval" value="30.0"/>
-      <param name="maxUrange" value="16.0"/>
+      <param name="maxUrange" value="3.9"/>
+      <param name="maxRange" value="4.0"/>
       <param name="sigma" value="0.05"/>
       <param name="kernelSize" value="1"/>
       <param name="lstep" value="0.05"/>
@@ -21,7 +22,7 @@
       <param name="angularUpdate" value="0.436"/>
       <param name="temporalUpdate" value="-1.0"/>
       <param name="resampleThreshold" value="0.5"/>
-      <param name="particles" value="80"/>
+      <param name="particles" value="30"/>
       <param name="xmin" value="-50.0"/>
       <param name="ymin" value="-50.0"/>
       <param name="xmax" value="50.0"/>
@@ -31,5 +32,6 @@
       <param name="llsamplestep" value="0.01"/>
       <param name="lasamplerange" value="0.005"/>
       <param name="lasamplestep" value="0.005"/>
+      <param name="minimumScore" value="400.0"/>
     </node>
 </launch>


### PR DESCRIPTION
In 'Navigatie' part of [ros_workshop part2](https://github.com/dortmans/ros_workshop/blob/master/oefeningen/deel2.md):
Creating a usable map for use with AMCL proves to be difficult (even with the laser).

I've modified and added parameters in *slam_gmapping.xml* to make the mapping process a bit easier. With these changes the laser sensor is still better at mapping, but the map itself won't jump around as much. 

- Added and set maxRange parameter to match the sensor defined in the world file (16 -> 4)
- Reduced maxUrange to be < maxRange as stated here: http://wiki.ros.org/gmapping#Parameters
- Set particles back to default value of 30 to improve cpu performance
- Added minimumScore parameter and set the value to 400 to improve map generation for sensors with limited range in big open spaces